### PR TITLE
cdo-1.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "1.7.1" %}
+
 package:
     name: cdo
-    version: 1.7.0
+    version: {{ version }}
 
 source:
-    fn: cdo-1.7.0.tar.gz
-    url: https://code.zmaw.de/attachments/download/11392/cdo-1.7.0.tar.gz
-    md5: cca30c3c79335ad734e1838806f7bfc2
+    fn: cdo-{{ version }}.tar.gz
+    url: https://code.zmaw.de/attachments/download/12070/cdo-{{ version }}.tar.gz
+    md5: f513a4bef1cf081cab3cfdc79d177bc5
 
 build:
     number: 0
@@ -32,7 +34,7 @@ test:
 
 about:
     home: https://code.zmaw.de/projects/cdo
-    license: GNU General Public License v2
+    license: GPLv2
     summary: CLI tools to manipulate and analyse Climate and NWP model Data
 
 extra:


### PR DESCRIPTION
## New features:
- select: added search key steptype, gridnum, gridname, zaxisnum, zaxisname
- expr, exprf, aexpr, aexprf: added support for function clon(x), clat(x), clev(x),
remove(x), ngp(x), nlev(x), size(x), missval(x), sellevel(x,k), sellevidx(x,k),
fldmin(x), fldmax(x), fldsum(x), fldmean(x), fldavg(x), fldstd(x), fldstd1(x), fldvar(x), fldvar1(x),
vertmin(x), vertmax(x), vertsum(x), vertmean(x), vertavg(x), vertstd(x), vertstd1(x), vertvar(x), vertvar1(x)
Here are some examples of the new expr features.

## New operators:
- contour: Contour plot
- shaded: Shaded contour plot
- grfill: Shaded gridfill plot
- vector: Lat/Lon vector plot
- graph: Line graph plot
- gmtxyz: Output GMT xyz format to create contour plots with the GMT module pscontour.
- gmtcells: Output GMT multiple segment format to create shaded gridfill plots with psxy.

## Fixed bugs:
- cdo -t table_file does not read variable name from table file [Bug 6312]
- One day shift backwards when converting to relative time axis with -r [Bug 6496]
- ydaypctl: check of verification date failed (bug fix)
- cat, copy, mergetime, select: remove time constant input fields for nfile>1 [Bug 6552]