### PR TITLE
Pin to libnetcdf 4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,19 +10,19 @@ source:
     md5: f513a4bef1cf081cab3cfdc79d177bc5
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win]
 
 requirements:
     build:
         - jasper
-        - libnetcdf 4.3*
+        - libnetcdf 4.4.*
         - netcdf-fortran
         - proj.4
         - libuuid
     run:
         - jasper
-        - libnetcdf 4.3*
+        - libnetcdf 4.4.*
         - netcdf-fortran
         - proj.4
         - libgcc


### PR DESCRIPTION
Let's wait for https://github.com/conda-forge/libnetcdf-feedstock/pull/1 to be merged first before merging this one.