### PR TITLE
Removed CMOR from master branch

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,6 @@ elif [[ $(uname) == 'Linux' ]]; then
               --with-udunits2=$PREFIX \
               --with-netcdf=$PREFIX \
               --with-hdf5=$PREFIX \
-              --with-cmor=$PREFIX \
               --with-ossp-uuid=$PREFIX 
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 48ed65cc5b436753c8e7f9eadd8aa97376698ce230ceafed2a4350a5b1a27148
 
 build:
-  number:
+  number: 4
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - udunits2
     - libxml2
     - fftw
-    - cmor
-    - json-c
     - ossuuid
   run:
     - jasper
@@ -36,8 +34,6 @@ requirements:
     - udunits2
     - libxml2
     - fftw
-    - cmor
-    - json-c
     - ossuuid
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 48ed65cc5b436753c8e7f9eadd8aa97376698ce230ceafed2a4350a5b1a27148
 
 build:
-  number: 3
+  number:
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
* [x] Bumped the build number (if the version is unchanged)
* [ ] Ensured the license file is being packaged.

CMOR requires python < 3 which is another reason to have it only in the dev branch:

UnsatisfiableError: The following specifications were found to be in conflict:
  - cdo=1.9.5 -> cmor -> python[version='>=2.7,<2.8.0a0']
  - python=3.6 

 <code>@<space/>conda-forge-admin, please rerender</code>