### PR TITLE
rebuild with HDF5 1.12.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -21,7 +21,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '9'
 hdf5:
-- 1.10.6
+- 1.12.1
 jasper:
 - '1'
 libnetcdf:

--- a/.ci_support/migrations/hdf51121.yaml
+++ b/.ci_support/migrations/hdf51121.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.12.1
+migrator_ts: 1625881538.220744

--- a/.ci_support/migrations/jasper2.yaml
+++ b/.ci_support/migrations/jasper2.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+jasper:
+- '2'
+migrator_ts: 1632848255.398075

--- a/.ci_support/migrations/jasper2.yaml
+++ b/.ci_support/migrations/jasper2.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-jasper:
-- '2'
-migrator_ts: 1632848255.398075

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '9'
 hdf5:
-- 1.10.6
+- 1.12.1
 jasper:
 - '1'
 libnetcdf:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Try2Code @ocefpaf
+* @Try2Code @akrherz @ocefpaf

--- a/README.md
+++ b/README.md
@@ -142,5 +142,6 @@ Feedstock Maintainers
 =====================
 
 * [@Try2Code](https://github.com/Try2Code/)
+* [@akrherz](https://github.com/akrherz/)
 * [@ocefpaf](https://github.com/ocefpaf/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,5 +56,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - akrherz
     - Try2Code
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: cc39c89bbb481d7b3945a06c56a8492047235f46ac363c4f0d980fccdde6677e
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin, please rerender

Unsure why bot migration did not attempt newer HDF5, so am trying myself :)