### PR TITLE
Enable aec + magics for CDO (plotting and szip compression for GRIB1)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,6 +24,7 @@ fi
             --with-hdf5=${PREFIX} \
             --with-ossp-uuid=${PREFIX} \
             --with-magics=${PREFIX} \
+            --with-szlib=${PREFIX} \
             ${ARGS}
 
 make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,6 +23,7 @@ fi
             --with-netcdf=${PREFIX} \
             --with-hdf5=${PREFIX} \
             --with-ossp-uuid=${PREFIX} \
+            --with-magics=${PREFIX} \
             ${ARGS}
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - fftw
     - ossuuid
     - magics
+    - aec
   run:
     - llvm-openmp  # [osx]
     - jasper
@@ -42,6 +43,7 @@ requirements:
     - fftw
     - ossuuid
     - magics
+    - aec
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - libxml2
     - fftw
     - ossuuid
+    - magics
   run:
     - llvm-openmp  # [osx]
     - jasper
@@ -40,6 +41,7 @@ requirements:
     - libxml2
     - fftw
     - ossuuid
+    - magics
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: cc39c89bbb481d7b3945a06c56a8492047235f46ac363c4f0d980fccdde6677e
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - fftw
     - ossuuid
     - magics
-    - aec
+    - libaec
   run:
     - llvm-openmp  # [osx]
     - jasper
@@ -43,7 +43,7 @@ requirements:
     - fftw
     - ossuuid
     - magics
-    - aec
+    - libaec
 
 test:
   files:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
