### PR TITLE
depend on libcurl

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.12.2
 jasper:
 - '2'
+libcurl:
+- '7'
 libnetcdf:
 - 4.8.1
 libuuid:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,6 +22,8 @@ hdf5:
 - 1.12.2
 jasper:
 - '2'
+libcurl:
+- '7'
 libnetcdf:
 - 4.8.1
 libuuid:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,6 +22,8 @@ hdf5:
 - 1.12.2
 jasper:
 - '2'
+libcurl:
+- '7'
 libnetcdf:
 - 4.8.1
 libuuid:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b871346c944b05566ab21893827c74616575deaad0b20eacb472b80b1fa528cc
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:
@@ -23,6 +23,7 @@ requirements:
   host:
     - llvm-openmp  # [osx]
     - jasper
+    - libcurl
     - libnetcdf
     - hdf5
     - proj
@@ -35,6 +36,7 @@ requirements:
   run:
     - llvm-openmp  # [osx]
     - jasper
+    - libcurl
     - libnetcdf
     - hdf5
     - proj


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Whilst reviewing build logs, I see:

```
WARNING (cdo,bin/cdo): Needed DSO lib/libcurl.4.dylib found in ['libcurl']
WARNING (cdo,bin/cdo): .. but ['libcurl'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```

We should depend on `libcurl`

@conda-forge-admin, please rerender